### PR TITLE
Fix for jobcan timeout, and error check on jira response

### DIFF
--- a/model/jobcan.js
+++ b/model/jobcan.js
@@ -110,8 +110,11 @@ class Jobcan {
   }
 
   async exists(page, xpath) {
-    const elements = await page.$x(xpath);
-    return elements.length > 0;
+    const elements = await page.evaluate((xpath) => {
+      const result = document.evaluate(xpath, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+      return result.snapshotLength;
+    }, xpath);
+    return elements > 0;
   }
 
   async hasRequested(page, date, vacation) {
@@ -178,8 +181,8 @@ class Jobcan {
       await page.click('#login_button');
 
       // Wait for navigation after login
-      await page.waitForNavigation();
-
+      await page.waitForSelector('#working_status', { visible: true });
+      
       for (const [key, value] of Object.entries(events)) {
         await page.goto(
           `https://ssl.jobcan.jp/employee/adit/modify?year=${value.year}&month=${value.month}&day=${value.day}`
@@ -187,9 +190,9 @@ class Jobcan {
 
         // Wait for the #ter_time element to appear
         await page.waitForSelector('#ter_time', { visible: true });
-
+        
         // Add a delay after navigation
-        await page.waitForTimeout(1000); // Wait for 1 second
+        await new Promise(resolve => setTimeout(resolve, 1000));
 
         if (
           !(await this.exists(
@@ -217,7 +220,7 @@ class Jobcan {
             );
 
             // Add a delay between actions
-            await page.waitForTimeout(1000); // Wait for 1 second
+            await new Promise(resolve => setTimeout(resolve, 1000));
 
             // Clock-Out
             await this.clear(page, '#ter_time');
@@ -227,7 +230,7 @@ class Jobcan {
             );
 
             // Add a delay before moving to the next entry
-            await page.waitForTimeout(1000); // Wait for 1 second
+            await new Promise(resolve => setTimeout(resolve, 1000));
           }
 
           if (this.holiday_map[value.vacation]) {


### PR DESCRIPTION
**JOBCAN**
1.) Fixed the issue with timeout. 
     Puppeteer waitForTimeout seems to be deprecated:
     `await page.waitForTimeout(1000);`
     Replaced with native solution:
     `await new Promise(resolve => setTimeout(resolve, 1000));`

2.) Also experienced the waitForNavigation never resolving after login so replaced with a selector:
     `await page.waitForNavigation();`
     Changed to:
     `await page.waitForSelector('#working_status', { visible: true });`
     
3.) There was another error with $x() function being undefined on the CdpPage class of puppeteer. I replaced the call in the "exists" function to native page.evaluate to resolve it.

**JIRA**
1.) When I initially setup I incorrectly setup my email as jfarr@moneytree.**co**.jp and when I ran it looked like the job worked fine, but actually nothing happened. I have added a check to the response to look for errorMessages and stop the job + print to log - so it's easier to know when something like this happens
